### PR TITLE
Implements: For Two Voting and Ties Resolver

### DIFF
--- a/src/outcomes.py
+++ b/src/outcomes.py
@@ -12,7 +12,12 @@ def plurality_outcome(s: np.array) -> List[Tuple[str, int]]:
 
 
 def for_two_outcome(s: np.array) -> List[Tuple[str, int]]:
-    return [()]
+    first_prefs = s[:2, :]
+    alternatives, votes = np.unique(first_prefs, return_counts=True)
+    winners_i = np.argwhere(votes == np.max(votes)).flatten()
+    winners = [(alternatives[i], np.max(votes)) for i in winners_i]
+    winners = tie_votes_resolver(winners, n=2)
+    return winners
 
 
 def veto_outcome(s: np.array) -> str:
@@ -24,7 +29,17 @@ def borda_outcome(s: np.array) -> str:
     return ""
 
 
-def tie_votes_resolver(r: np.array):
+def tie_votes_resolver(r: np.array, n: int = 1):
+    """
+    r: voting result
+    n: num winners
+    """
+    if len(r) == n:
+        return r
+
+    # Sort result alphabetically and get first n winners
+    sorted_r = np.sort([w[0] for w in r])[:n]
+    r = [(w, r[0][1]) for w in sorted_r]
     return r
 
 

--- a/test/test_outcomes.py
+++ b/test/test_outcomes.py
@@ -14,8 +14,13 @@ class TestOutComes(unittest.TestCase):
             ]
         )
 
-    # TODO
-    """ 
+    def test_plurality_should_return_general_expected_outcome(self):
+        expected_outcome = [("B", 3)]
+        outcome = o.plurality_outcome(self.s)
+
+        self.assertCountEqual(outcome, expected_outcome)
+        self.assertListEqual(outcome, expected_outcome)
+
     def test_plurality_should_resolve_ties(self):
         # Both B and C have max num votes (2)
         self.s[0, :] = ["C", "B", "C", "A", "B"]
@@ -24,11 +29,19 @@ class TestOutComes(unittest.TestCase):
 
         self.assertCountEqual(outcome, expected_outcome)
         self.assertListEqual(outcome, expected_outcome)
-    """
 
-    def test_plurality_should_returns_general_expected_outcome(self):
-        expected_outcome = [("B", 3)]
-        outcome = o.plurality_outcome(self.s)
+    def test_for_two_should_return_general_expected_outcome(self):
+        expected_outcome = [("B", 3), ("D", 3)]
+        outcome = o.for_two_outcome(self.s)
+
+        self.assertCountEqual(outcome, expected_outcome)
+        self.assertListEqual(outcome, expected_outcome)
+
+    def test_for_two_should_resolve_ties(self):
+        # A, B, C have 3 votes
+        self.s[0, 0] = "A"
+        expected_outcome = [("A", 3), ("B", 3)]
+        outcome = o.for_two_outcome(self.s)
 
         self.assertCountEqual(outcome, expected_outcome)
         self.assertListEqual(outcome, expected_outcome)

--- a/tva.ipynb
+++ b/tva.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Implements `for_two_outcome()` and `tie_votes_resolver()`. Adds tests for `for_two_outcomes()` that verify that the function gives the correct output and resolves ties with 3 alternatives with equal voting.